### PR TITLE
Increase timeout

### DIFF
--- a/.github/workflows/test-addons.yml
+++ b/.github/workflows/test-addons.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
On the text addon, 15 minutes is sometimes not enough. I know this setting is good to push us to optimize tests but I suggest for now to increase it to 20 minutes and deal with this later when all other things will be fixed