### PR TITLE
Separate single environment test into its own workflow

### DIFF
--- a/.github/workflows/test-addons.yml
+++ b/.github/workflows/test-addons.yml
@@ -2,18 +2,9 @@ name: Test
 
 on:
   workflow_call:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
-    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -54,66 +45,10 @@ jobs:
             tox_env: orange-latest
             pyqt: '5.15.*'
             experimental: false
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install linux system dependencies
-        # PyQt6 need special system dependencies on Ubuntu
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libxcb-shape0 libxcb-cursor0 glibc-tools
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade tox
-
-      - name: Test with Tox at Ubuntu
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          catchsegv xvfb-run -a -s "$XVFBARGS" tox -e ${{ matrix.tox_env }}
-        env:
-          # Set pyqt and webengine versions.
-          PYQT_PYPI_NAME: "${{ startsWith(matrix.pyqt, '5')  && 'PyQt5' || 'PyQt6' }}"
-          PYQT_PYPI_VERSION: ${{ matrix.pyqt }}
-          WEBENGINE_PYPI_NAME: "${{ startsWith(matrix.pyqt, '5')  && 'PyQtWebEngine' || 'PyQt6-WebEngine' }}"
-          WEBENGINE_PYPI_VERSION: ${{ matrix.pyqt }}
-
-          # Need this otherwise unittest installs a warning filter that overrides
-          # our desire to have OrangeDeprecationWarnings raised
-          PYTHONWARNINGS: module
-          # for xvfb at Ubuntu
-          XVFBARGS: "-screen 0 1280x1024x24"
-          # on Ubuntu QTWEBENGINE_CHROMIUM_FLAGS needs to be set for webview to work 
-          QTWEBENGINE_CHROMIUM_FLAGS: "--disable-gpu --no-sandbox"
-
-      - name: Test with Tox at other systems
-        if: matrix.os != 'ubuntu-latest'
-        run: tox -e ${{ matrix.tox_env }}
-        env:
-          # Set pyqt and webengine versions.
-          PYQT_PYPI_NAME: "${{ startsWith(matrix.pyqt, '5')  && 'PyQt5' || 'PyQt6' }}"
-          PYQT_PYPI_VERSION: ${{ matrix.pyqt }}
-          WEBENGINE_PYPI_NAME: "${{ startsWith(matrix.pyqt, '5')  && 'PyQtWebEngine' || 'PyQt6-WebEngine' }}"
-          WEBENGINE_PYPI_VERSION: ${{ matrix.pyqt }}
-
-          # Raise deprecations as errors in our tests only when testing orange-oldest and orange-released.
-          ORANGE_DEPRECATIONS_ERROR: "${{ matrix.tox_env != 'orange-latest' && '1' || '' }}"
-          # Need this otherwise unittest installs a warning filter that overrides
-          # our desire to have OrangeDeprecationWarnings raised
-          PYTHONWARNINGS: module
-
-      - name: Upload code coverage
-        if: |
-          matrix.python-version == '3.10' &&
-          matrix.os == 'ubuntu-latest' &&
-          matrix.tox_env == 'orange-released'
-        run: |
-          pip install codecov
-          codecov
+    uses: ./.github/workflows/test-job.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      tox_env: ${{ matrix.tox_env }}
+      pyqt: ${{ matrix.pyqt }}
+      experimental: ${{ matrix.experimental }}

--- a/.github/workflows/test-job.yml
+++ b/.github/workflows/test-job.yml
@@ -1,0 +1,89 @@
+name: Job
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+      tox_env:
+        required: true
+        type: string
+      pyqt:
+        required: true
+        type: string
+      experimental:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    name: ${{ inputs.tox_env }} ${{ inputs.os }} py${{ inputs.python-version }} qt${{ inputs.pyqt }}
+    runs-on: ${{ inputs.os }}
+    continue-on-error: ${{ inputs.experimental }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install linux system dependencies
+        # PyQt6 need special system dependencies on Ubuntu
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libxcb-shape0 libxcb-cursor0 glibc-tools
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+
+      - name: Test with Tox at Ubuntu
+        if: inputs.os == 'ubuntu-latest'
+        run: |
+          catchsegv xvfb-run -a -s "$XVFBARGS" tox -e ${{ inputs.tox_env }}
+        env:
+          # Set pyqt and webengine versions.
+          PYQT_PYPI_NAME: "${{ startsWith(inputs.pyqt, '5')  && 'PyQt5' || 'PyQt6' }}"
+          PYQT_PYPI_VERSION: ${{ inputs.pyqt }}
+          WEBENGINE_PYPI_NAME: "${{ startsWith(inputs.pyqt, '5')  && 'PyQtWebEngine' || 'PyQt6-WebEngine' }}"
+          WEBENGINE_PYPI_VERSION: ${{ inputs.pyqt }}
+
+          # Need this otherwise unittest installs a warning filter that overrides
+          # our desire to have OrangeDeprecationWarnings raised
+          PYTHONWARNINGS: module
+          # for xvfb at Ubuntu
+          XVFBARGS: "-screen 0 1280x1024x24"
+          # on Ubuntu QTWEBENGINE_CHROMIUM_FLAGS needs to be set for webview to work 
+          QTWEBENGINE_CHROMIUM_FLAGS: "--disable-gpu --no-sandbox"
+
+      - name: Test with Tox at other systems
+        if: inputs.os != 'ubuntu-latest'
+        run: tox -e ${{ inputs.tox_env }}
+        env:
+          # Set pyqt and webengine versions.
+          PYQT_PYPI_NAME: "${{ startsWith(inputs.pyqt, '5')  && 'PyQt5' || 'PyQt6' }}"
+          PYQT_PYPI_VERSION: ${{ inputs.pyqt }}
+          WEBENGINE_PYPI_NAME: "${{ startsWith(inputs.pyqt, '5')  && 'PyQtWebEngine' || 'PyQt6-WebEngine' }}"
+          WEBENGINE_PYPI_VERSION: ${{ inputs.pyqt }}
+
+          # Raise deprecations as errors in our tests only when testing orange-oldest and orange-released.
+          ORANGE_DEPRECATIONS_ERROR: "${{ inputs.tox_env != 'orange-latest' && '1' || '' }}"
+          # Need this otherwise unittest installs a warning filter that overrides
+          # our desire to have OrangeDeprecationWarnings raised
+          PYTHONWARNINGS: module
+
+      - name: Upload code coverage
+        if: |
+          inputs.python-version == '3.10' &&
+          inputs.os == 'ubuntu-latest' &&
+          inputs.tox_env == 'orange-released'
+        run: |
+          pip install codecov
+          codecov


### PR DESCRIPTION
This is a refactor which should not break anything.

If single environment tests are separated, add-ons call test specific additional environments. For example:

```
jobs:
  normal:
    name: Usual
    uses: biolab/orange-ci-cd/.github/workflows/test-addons.yml@master
  dask:
    name: Dask
    uses: biolab/orange-ci-cd/.github/workflows/test-single-env.yml@master
    with:
      os: ubuntu-latest
      python-version: '3.10'
      tox_env: dask
      pyqt: '5.15.*'
```

The above worklow runs the standard add-on tests plus an additional test with a specific tox environment (`dask`). See quasars/orange-spectroscopy#702 for that PR.