### PR TITLE
test-addons: Bump pyqt6 version to 6.7 (Fixes #10)

### DIFF
--- a/.github/workflows/test-addons.yml
+++ b/.github/workflows/test-addons.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         python-version: ['3.10']
         tox_env: [orange-released]
-        pyqt: ['5.15.*', '6.6.*']
+        pyqt: ['5.15.*', '6.7.*']
         experimental: [false]
         include:
           - os: windows-latest


### PR DESCRIPTION
The PyQt6 6.6.* series wheels (at least manylinux) seem to be broken: `from PyQt6.QtGui import *` line always fails.