### PR TITLE
Add python 3.12 to tests

### DIFF
--- a/.github/workflows/test-addons.yml
+++ b/.github/workflows/test-addons.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11']
         tox_env: [orange-released]
         pyqt: ['5.15.*', '6.7.*']
         experimental: [false]
@@ -31,17 +31,17 @@ jobs:
             experimental: false
 
           - os: windows-latest
-            python-version: '3.11'
+            python-version: '3.12'
             tox_env: orange-latest
             pyqt: '5.15.*'
             experimental: false
           - os: macOS-latest
-            python-version: '3.11'
+            python-version: '3.12'
             tox_env: orange-latest
             pyqt: '5.15.*'
             experimental: false
           - os: ubuntu-latest
-            python-version: '3.11'
+            python-version: '3.12'
             tox_env: orange-latest
             pyqt: '5.15.*'
             experimental: false


### PR DESCRIPTION
These tests have been overdue long ago. Let's see if pkg_resources starts making trouble.