### PR TITLE
Smaller testing matrix

### DIFF
--- a/.github/workflows/test-addons.yml
+++ b/.github/workflows/test-addons.yml
@@ -9,9 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macOS-latest, windows-latest]
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13']
         tox_env: [orange-released]
-        pyqt: ['5.15.*', '6.8.*']
+        pyqt: ['6.8.*']
         experimental: [false]
         include:
           - os: windows-latest
@@ -43,6 +43,11 @@ jobs:
             python-version: '3.14'
             tox_env: orange-latest
             pyqt: '6.8.*'
+            experimental: false
+          - os: ubuntu-24.04
+            python-version: '3.14'
+            tox_env: orange-latest
+            pyqt: '5.15.*'
             experimental: false
     uses: ./.github/workflows/test-job.yml
     with:

--- a/.github/workflows/test-addons.yml
+++ b/.github/workflows/test-addons.yml
@@ -30,17 +30,17 @@ jobs:
             pyqt: '5.15.*'
             experimental: false
           - os: windows-latest
-            python-version: '3.13'
+            python-version: '3.14'
             tox_env: orange-latest
             pyqt: '6.8.*'
             experimental: false
           - os: macOS-latest
-            python-version: '3.13'
+            python-version: '3.14'
             tox_env: orange-latest
             pyqt: '6.8.*'
             experimental: false
           - os: ubuntu-24.04
-            python-version: '3.13'
+            python-version: '3.14'
             tox_env: orange-latest
             pyqt: '6.8.*'
             experimental: false


### PR DESCRIPTION
The last config runs 30 tests, which is too much.

Only use python 3.11 for -oldest tests, and 3.14 for -latest. 

Also, limit Qt to mostly Qt6: use Qt6 for testing except for the -oldest tests and a single -released test.